### PR TITLE
fix(security): close account-membership role escalation (P0)

### DIFF
--- a/lib/grocery_planner/accounts/account.ex
+++ b/lib/grocery_planner/accounts/account.ex
@@ -40,7 +40,7 @@ defmodule GroceryPlanner.Accounts.Account do
     end
 
     policy action_type([:update, :destroy]) do
-      authorize_if relates_to_actor_via([:memberships, :user], filter: [role: [:owner, :admin]])
+      authorize_if {GroceryPlanner.Checks.ActorOwnerOrAdminOfAccount, account_id_field: :id}
     end
   end
 

--- a/lib/grocery_planner/accounts/account_membership.ex
+++ b/lib/grocery_planner/accounts/account_membership.ex
@@ -35,8 +35,16 @@ defmodule GroceryPlanner.Accounts.AccountMembership do
   end
 
   policies do
-    policy always() do
-      authorize_if always()
+    policy action_type(:read) do
+      authorize_if relates_to_actor_via([:account, :memberships, :user])
+    end
+
+    policy action_type(:create) do
+      authorize_if {GroceryPlanner.Checks.ActorOwnerOrAdminOfAccount, []}
+    end
+
+    policy action_type([:update, :destroy]) do
+      authorize_if {GroceryPlanner.Checks.ActorOwnerOrAdminOfAccount, []}
     end
   end
 

--- a/lib/grocery_planner/accounts/user.ex
+++ b/lib/grocery_planner/accounts/user.ex
@@ -102,8 +102,18 @@ defmodule GroceryPlanner.Accounts.User do
   end
 
   policies do
-    policy always() do
+    policy action_type(:create) do
       authorize_if always()
+    end
+
+    policy action_type(:read) do
+      authorize_if expr(id == ^actor(:id))
+      # account-mates need to see each other's name/email on the settings roster
+      authorize_if relates_to_actor_via([:memberships, :account, :memberships, :user])
+    end
+
+    policy action_type([:update, :destroy]) do
+      authorize_if expr(id == ^actor(:id))
     end
   end
 

--- a/lib/grocery_planner/checks/actor_member_of_account.ex
+++ b/lib/grocery_planner/checks/actor_member_of_account.ex
@@ -12,7 +12,7 @@ defmodule GroceryPlanner.Checks.ActorMemberOfAccount do
     exists? =
       GroceryPlanner.Accounts.AccountMembership
       |> Ash.Query.filter(account_id == ^account_id and user_id == ^actor.id)
-      |> Ash.exists?(domain: GroceryPlanner.Accounts)
+      |> Ash.exists?(domain: GroceryPlanner.Accounts, authorize?: false)
 
     {:ok, exists?}
   end

--- a/lib/grocery_planner/checks/actor_owner_or_admin_of_account.ex
+++ b/lib/grocery_planner/checks/actor_owner_or_admin_of_account.ex
@@ -1,0 +1,47 @@
+defmodule GroceryPlanner.Checks.ActorOwnerOrAdminOfAccount do
+  @moduledoc false
+  use Ash.Policy.Check
+  require Ash.Query
+
+  def strict_check(actor, context, opts) when not is_nil(actor) do
+    case account_id(context, opts) do
+      nil ->
+        {:ok, false}
+
+      account_id ->
+        exists? =
+          GroceryPlanner.Accounts.AccountMembership
+          |> Ash.Query.filter(
+            account_id == ^account_id and user_id == ^actor.id and role in [:owner, :admin]
+          )
+          |> Ash.exists?(domain: GroceryPlanner.Accounts, authorize?: false)
+
+        {:ok, exists?}
+    end
+  end
+
+  def strict_check(_, _, _), do: {:ok, false}
+
+  # On create there is no persisted record yet, so the account id comes from
+  # whatever attribute/argument the changeset is setting.
+  defp account_id(%{changeset: %{action_type: :create} = changeset}, opts) do
+    field = Keyword.get(opts, :account_id_field, :account_id)
+
+    Ash.Changeset.get_attribute(changeset, field) ||
+      Ash.Changeset.get_argument(changeset, field)
+  end
+
+  # On update/destroy, read the account id off the existing record. Defaults to
+  # `:account_id` (a belongs_to attribute) but pass `account_id_field: :id` when
+  # the resource being authorized *is* the account itself.
+  defp account_id(%{changeset: %{data: data}}, opts) do
+    field = Keyword.get(opts, :account_id_field, :account_id)
+    Map.get(data, field)
+  end
+
+  defp account_id(_, _), do: nil
+
+  def describe(_opts), do: "actor must be an owner or admin of the account"
+
+  def match?(_actor, _context, _opts), do: true
+end

--- a/lib/grocery_planner_web/auth.ex
+++ b/lib/grocery_planner_web/auth.ex
@@ -52,7 +52,7 @@ defmodule GroceryPlannerWeb.Auth do
 
   defp find_current_user(session) do
     with user_id when not is_nil(user_id) <- session["user_id"],
-         {:ok, user} <- GroceryPlanner.Accounts.User.by_id(user_id) do
+         {:ok, user} <- GroceryPlanner.Accounts.User.by_id(user_id, authorize?: false) do
       user
     else
       _ -> nil
@@ -71,7 +71,7 @@ defmodule GroceryPlannerWeb.Auth do
   end
 
   def by_id!(user_id) do
-    case GroceryPlanner.Accounts.User.by_id(user_id) do
+    case GroceryPlanner.Accounts.User.by_id(user_id, authorize?: false) do
       {:ok, user} -> user
       _ -> nil
     end

--- a/lib/grocery_planner_web/controllers/api/auth_controller.ex
+++ b/lib/grocery_planner_web/controllers/api/auth_controller.ex
@@ -4,7 +4,7 @@ defmodule GroceryPlannerWeb.Api.AuthController do
   alias GroceryPlanner.Accounts.User
 
   def sign_in(conn, %{"email" => email, "password" => password}) do
-    with {:ok, user} <- User.by_email(email),
+    with {:ok, user} <- User.by_email(email, authorize?: false),
          true <- Bcrypt.verify_pass(password, user.hashed_password) do
       token = Phoenix.Token.sign(GroceryPlannerWeb.Endpoint, "user auth", user.id)
 

--- a/lib/grocery_planner_web/controllers/auth_controller.ex
+++ b/lib/grocery_planner_web/controllers/auth_controller.ex
@@ -26,7 +26,7 @@ defmodule GroceryPlannerWeb.AuthController do
   end
 
   defp authenticate_user(email, password) do
-    case Accounts.User.by_email(email) do
+    case Accounts.User.by_email(email, authorize?: false) do
       {:ok, user} when not is_nil(user) ->
         if Bcrypt.verify_pass(password, user.hashed_password) do
           {:ok, user}

--- a/lib/grocery_planner_web/live/auth/forgot_password_live.ex
+++ b/lib/grocery_planner_web/live/auth/forgot_password_live.ex
@@ -28,7 +28,7 @@ defmodule GroceryPlannerWeb.Auth.ForgotPasswordLive do
   end
 
   defp send_reset_email_if_user_exists(email) do
-    case Accounts.User.by_email(email) do
+    case Accounts.User.by_email(email, authorize?: false) do
       {:ok, user} when not is_nil(user) ->
         case Accounts.User.request_password_reset(user, authorize?: false) do
           {:ok, updated_user} ->

--- a/lib/grocery_planner_web/live/auth/reset_password_live.ex
+++ b/lib/grocery_planner_web/live/auth/reset_password_live.ex
@@ -63,7 +63,7 @@ defmodule GroceryPlannerWeb.Auth.ResetPasswordLive do
   end
 
   defp validate_token(token) do
-    case Accounts.User.by_reset_token(token) do
+    case Accounts.User.by_reset_token(token, authorize?: false) do
       {:ok, user} when not is_nil(user) ->
         if token_expired?(user.reset_password_sent_at) do
           {:error, :expired}

--- a/lib/grocery_planner_web/live/meal_planner_live.ex
+++ b/lib/grocery_planner_web/live/meal_planner_live.ex
@@ -85,9 +85,11 @@ defmodule GroceryPlannerWeb.MealPlannerLive do
   # Layout switching
   def handle_event("meal_planner_set_layout", %{"layout" => layout}, socket)
       when layout in ["explorer", "focus", "power"] do
-    case GroceryPlanner.Accounts.User.update(socket.assigns.current_user, %{
-           meal_planner_layout: layout
-         }) do
+    case GroceryPlanner.Accounts.User.update(
+           socket.assigns.current_user,
+           %{meal_planner_layout: layout},
+           actor: socket.assigns.current_user
+         ) do
       {:ok, user} ->
         socket =
           socket

--- a/lib/grocery_planner_web/live/settings_live.ex
+++ b/lib/grocery_planner_web/live/settings_live.ex
@@ -12,8 +12,9 @@ defmodule GroceryPlannerWeb.SettingsLive do
       Voting.voting_active?(socket.assigns.current_account.id, socket.assigns.current_user)
 
     socket = assign(socket, :current_scope, socket.assigns.current_account)
-    account = Ash.load!(socket.assigns.current_account, [:memberships])
-    memberships = Ash.load!(account.memberships, [:user])
+    actor = socket.assigns.current_user
+    account = Ash.load!(socket.assigns.current_account, [:memberships], actor: actor)
+    memberships = Ash.load!(account.memberships, [:user], actor: actor)
 
     current_membership =
       Enum.find(memberships, fn m -> m.user_id == socket.assigns.current_user.id end)
@@ -166,13 +167,17 @@ defmodule GroceryPlannerWeb.SettingsLive do
   end
 
   def handle_event("update_user", %{"user" => params}, socket) do
-    case Accounts.User.update(socket.assigns.current_user, %{
-           name: params["name"],
-           email: params["email"],
-           theme: params["theme"],
-           meal_planner_layout: params["meal_planner_layout"],
-           family_focus: params["family_focus"] == "true"
-         }) do
+    case Accounts.User.update(
+           socket.assigns.current_user,
+           %{
+             name: params["name"],
+             email: params["email"],
+             theme: params["theme"],
+             meal_planner_layout: params["meal_planner_layout"],
+             family_focus: params["family_focus"] == "true"
+           },
+           actor: socket.assigns.current_user
+         ) do
       {:ok, user} ->
         {:noreply,
          socket
@@ -198,57 +203,75 @@ defmodule GroceryPlannerWeb.SettingsLive do
   end
 
   def handle_event("send_invitation", %{"email" => email, "role" => role}, socket) do
-    case Accounts.User.by_email(email) do
-      {:ok, user} ->
-        role_atom = String.to_existing_atom(role)
+    actor = socket.assigns.current_user
 
-        case Accounts.AccountMembership.create(
-               socket.assigns.current_account.id,
-               user.id,
-               %{role: role_atom}
-             ) do
-          {:ok, _membership} ->
-            memberships =
-              socket.assigns.current_account
-              |> Ash.load!([:memberships])
-              |> Map.get(:memberships)
-              |> Ash.load!([:user])
+    if socket.assigns.current_role in [:owner, :admin] do
+      # authorize?: false is safe here: this only resolves an email to a user id
+      # for the membership create below, which is itself role-gated by policy.
+      case Accounts.User.by_email(email, authorize?: false) do
+        {:ok, user} ->
+          role_atom = String.to_existing_atom(role)
 
-            {:noreply,
-             socket
-             |> put_flash(:info, "Member added successfully")
-             |> assign(:memberships, memberships)
-             |> assign(:show_invite_form, false)
-             |> assign(:invite_form, to_form(%{}))}
+          case Accounts.AccountMembership.create(
+                 socket.assigns.current_account.id,
+                 user.id,
+                 %{role: role_atom},
+                 actor: actor
+               ) do
+            {:ok, _membership} ->
+              memberships =
+                socket.assigns.current_account
+                |> Ash.load!([:memberships], actor: actor)
+                |> Map.get(:memberships)
+                |> Ash.load!([:user], actor: actor)
 
-          {:error, _} ->
-            {:noreply, put_flash(socket, :error, "Failed to add member")}
-        end
+              {:noreply,
+               socket
+               |> put_flash(:info, "Member added successfully")
+               |> assign(:memberships, memberships)
+               |> assign(:show_invite_form, false)
+               |> assign(:invite_form, to_form(%{}))}
 
-      {:error, _} ->
-        {:noreply, put_flash(socket, :error, "User with that email not found")}
+            {:error, _} ->
+              {:noreply, put_flash(socket, :error, "Failed to add member")}
+          end
+
+        {:error, _} ->
+          {:noreply, put_flash(socket, :error, "User with that email not found")}
+      end
+    else
+      {:noreply, put_flash(socket, :error, "You do not have permission to add members")}
     end
   end
 
   def handle_event("remove_member", %{"id" => id}, socket) do
-    membership =
-      Enum.find(socket.assigns.memberships, fn m -> m.id == id end)
+    actor = socket.assigns.current_user
+    membership = Enum.find(socket.assigns.memberships, fn m -> m.id == id end)
 
-    case Accounts.AccountMembership.destroy(membership) do
-      :ok ->
-        memberships =
-          socket.assigns.current_account
-          |> Ash.load!([:memberships])
-          |> Map.get(:memberships)
-          |> Ash.load!([:user])
-
-        {:noreply,
-         socket
-         |> put_flash(:info, "Member removed successfully")
-         |> assign(:memberships, memberships)}
-
-      {:error, _} ->
+    cond do
+      is_nil(membership) ->
         {:noreply, put_flash(socket, :error, "Failed to remove member")}
+
+      socket.assigns.current_role not in [:owner, :admin] ->
+        {:noreply, put_flash(socket, :error, "You do not have permission to remove members")}
+
+      true ->
+        case Accounts.AccountMembership.destroy(membership, actor: actor) do
+          :ok ->
+            memberships =
+              socket.assigns.current_account
+              |> Ash.load!([:memberships], actor: actor)
+              |> Map.get(:memberships)
+              |> Ash.load!([:user], actor: actor)
+
+            {:noreply,
+             socket
+             |> put_flash(:info, "Member removed successfully")
+             |> assign(:memberships, memberships)}
+
+          {:error, _} ->
+            {:noreply, put_flash(socket, :error, "Failed to remove member")}
+        end
     end
   end
 end

--- a/lib/grocery_planner_web/plugs/api_auth.ex
+++ b/lib/grocery_planner_web/plugs/api_auth.ex
@@ -14,7 +14,7 @@ defmodule GroceryPlannerWeb.Plugs.ApiAuth do
       with ["Bearer " <> token] <- get_req_header(conn, "authorization"),
            {:ok, user_id} <-
              Phoenix.Token.verify(GroceryPlannerWeb.Endpoint, "user auth", token, max_age: 86_400),
-           {:ok, user} <- User.by_id(user_id),
+           {:ok, user} <- User.by_id(user_id, authorize?: false),
            {:ok, user} <- Ash.load(user, :accounts, authorize?: false) do
         account = List.first(user.accounts)
 

--- a/test/grocery_planner/accounts/account_membership_test.exs
+++ b/test/grocery_planner/accounts/account_membership_test.exs
@@ -119,6 +119,121 @@ defmodule GroceryPlanner.Accounts.AccountMembershipTest do
     end
   end
 
+  describe "authorization" do
+    setup %{account: account, user: owner} do
+      {:ok, owner_membership} =
+        AccountMembership.create(account.id, owner.id, %{role: :owner}, authorize?: false)
+
+      {:ok, member} = User.create("member2@example.com", "Member", "password123456")
+
+      {:ok, member_membership} =
+        AccountMembership.create(account.id, member.id, %{role: :member}, authorize?: false)
+
+      %{
+        owner: owner,
+        owner_membership: owner_membership,
+        member: member,
+        member_membership: member_membership
+      }
+    end
+
+    test "owner can add a member", %{account: account, owner: owner} do
+      {:ok, invitee} = User.create("invitee@example.com", "Invitee", "password123456")
+
+      assert {:ok, membership} =
+               AccountMembership.create(account.id, invitee.id, %{role: :member},
+                 actor: owner,
+                 authorize?: true
+               )
+
+      assert membership.role == :member
+    end
+
+    test "member cannot add themselves as owner (role escalation)", %{
+      account: account,
+      member: member
+    } do
+      {:ok, colluder} = User.create("colluder@example.com", "Colluder", "password123456")
+
+      result =
+        AccountMembership.create(account.id, colluder.id, %{role: :owner},
+          actor: member,
+          authorize?: true
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "member cannot add anyone at all", %{account: account, member: member} do
+      {:ok, invitee} = User.create("invitee2@example.com", "Invitee", "password123456")
+
+      result =
+        AccountMembership.create(account.id, invitee.id, %{role: :member},
+          actor: member,
+          authorize?: true
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "outsider cannot add members to an account they don't belong to", %{account: account} do
+      {:ok, outsider} = User.create("outsider@example.com", "Outsider", "password123456")
+      {:ok, invitee} = User.create("invitee3@example.com", "Invitee", "password123456")
+
+      result =
+        AccountMembership.create(account.id, invitee.id, %{role: :member},
+          actor: outsider,
+          authorize?: true
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "owner can remove a member", %{owner: owner, member_membership: member_membership} do
+      assert :ok = AccountMembership.destroy(member_membership, actor: owner, authorize?: true)
+    end
+
+    test "member cannot remove the owner's membership", %{
+      owner_membership: owner_membership,
+      member: member
+    } do
+      result = AccountMembership.destroy(owner_membership, actor: member, authorize?: true)
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "member cannot change their own role to owner", %{
+      member: member,
+      member_membership: member_membership
+    } do
+      result =
+        AccountMembership.update(member_membership, %{role: :owner},
+          actor: member,
+          authorize?: true
+        )
+
+      assert {:error, %Ash.Error.Forbidden{}} = result
+    end
+
+    test "admin can change a member's role", %{
+      account: account,
+      member_membership: member_membership
+    } do
+      {:ok, admin} = User.create("admin2@example.com", "Admin", "password123456")
+
+      {:ok, _admin_membership} =
+        AccountMembership.create(account.id, admin.id, %{role: :admin}, authorize?: false)
+
+      assert {:ok, updated} =
+               AccountMembership.update(member_membership, %{role: :admin},
+                 actor: admin,
+                 authorize?: true
+               )
+
+      assert updated.role == :admin
+    end
+  end
+
   describe "role constraints" do
     test "all valid roles are accepted", %{account: account} do
       valid_roles = [:owner, :admin, :member]

--- a/test/grocery_planner/accounts/account_test.exs
+++ b/test/grocery_planner/accounts/account_test.exs
@@ -94,9 +94,7 @@ defmodule GroceryPlanner.Accounts.AccountTest do
           assert Enum.any?(errors, fn e -> match?(%Ash.Error.Forbidden{}, e) end)
 
         {:ok, _} ->
-          # Policy may allow members to update - skip this test if so
-          # This documents the current behavior
-          assert true
+          flunk("Expected regular member update to be forbidden")
       end
     end
 

--- a/test/grocery_planner/accounts/user_password_reset_test.exs
+++ b/test/grocery_planner/accounts/user_password_reset_test.exs
@@ -32,13 +32,14 @@ defmodule GroceryPlanner.Accounts.UserPasswordResetTest do
       {:ok, user} = create_test_user()
       {:ok, updated_user} = User.request_password_reset(user, authorize?: false)
 
-      {:ok, found_user} = User.by_reset_token(updated_user.reset_password_token)
+      {:ok, found_user} =
+        User.by_reset_token(updated_user.reset_password_token, authorize?: false)
 
       assert found_user.id == user.id
     end
 
     test "returns error for invalid token" do
-      result = User.by_reset_token("invalid-token")
+      result = User.by_reset_token("invalid-token", authorize?: false)
 
       assert {:error, %Ash.Error.Invalid{}} = result
     end

--- a/test/grocery_planner/accounts/user_theme_test.exs
+++ b/test/grocery_planner/accounts/user_theme_test.exs
@@ -18,7 +18,7 @@ defmodule GroceryPlanner.Accounts.UserThemeTest do
             "password123password123"
           )
 
-        assert {:ok, updated} = User.update(user, %{theme: theme})
+        assert {:ok, updated} = User.update(user, %{theme: theme}, actor: user)
         assert updated.theme == theme
       end
     end
@@ -32,11 +32,11 @@ defmodule GroceryPlanner.Accounts.UserThemeTest do
         )
 
       # Test with old "progressive" theme (should be invalid now)
-      assert {:error, error} = User.update(user, %{theme: "progressive"})
+      assert {:error, error} = User.update(user, %{theme: "progressive"}, actor: user)
       assert error.errors |> Enum.any?(fn e -> e.field == :theme end)
 
       # Test with random invalid theme
-      assert {:error, error} = User.update(user, %{theme: "invalid_theme"})
+      assert {:error, error} = User.update(user, %{theme: "invalid_theme"}, actor: user)
       assert error.errors |> Enum.any?(fn e -> e.field == :theme end)
     end
 
@@ -61,7 +61,7 @@ defmodule GroceryPlanner.Accounts.UserThemeTest do
 
       assert user.theme == "light"
 
-      {:ok, updated} = User.update(user, %{theme: "cyberpunk"})
+      {:ok, updated} = User.update(user, %{theme: "cyberpunk"}, actor: user)
       assert updated.theme == "cyberpunk"
     end
   end

--- a/test/grocery_planner/analytics/trends_test.exs
+++ b/test/grocery_planner/analytics/trends_test.exs
@@ -19,7 +19,9 @@ defmodule GroceryPlanner.Analytics.TrendsTest do
       |> Ash.create!()
 
     # Link user to account
-    case Accounts.AccountMembership.create(account.id, user.id, %{role: :owner}) do
+    case Accounts.AccountMembership.create(account.id, user.id, %{role: :owner},
+           authorize?: false
+         ) do
       {:ok, membership} ->
         membership
 

--- a/test/grocery_planner_web/live/auth/forgot_password_live_test.exs
+++ b/test/grocery_planner_web/live/auth/forgot_password_live_test.exs
@@ -52,7 +52,7 @@ defmodule GroceryPlannerWeb.Auth.ForgotPasswordLiveTest do
     |> render_submit()
 
     # Verify the user now has a reset token
-    {:ok, updated_user} = User.by_email("resettest@example.com")
+    {:ok, updated_user} = User.by_email("resettest@example.com", authorize?: false)
     assert updated_user.reset_password_token != nil
     assert updated_user.reset_password_sent_at != nil
   end

--- a/test/grocery_planner_web/live/auth/reset_password_live_test.exs
+++ b/test/grocery_planner_web/live/auth/reset_password_live_test.exs
@@ -40,7 +40,7 @@ defmodule GroceryPlannerWeb.Auth.ResetPasswordLiveTest do
       assert_redirect(view, "/sign-in")
 
       # Verify password was changed
-      {:ok, updated_user} = User.by_id(user.id)
+      {:ok, updated_user} = User.by_id(user.id, authorize?: false)
       assert Bcrypt.verify_pass("newpassword123", updated_user.hashed_password)
       assert updated_user.reset_password_token == nil
     end

--- a/test/grocery_planner_web/live/meal_planner_explorer_live_test.exs
+++ b/test/grocery_planner_web/live/meal_planner_explorer_live_test.exs
@@ -8,7 +8,8 @@ defmodule GroceryPlannerWeb.MealPlannerExplorerLiveTest do
     account = create_account()
     user = create_user(account)
 
-    {:ok, user} = GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "explorer"})
+    {:ok, user} =
+      GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "explorer"}, actor: user)
 
     conn =
       build_conn()

--- a/test/grocery_planner_web/live/meal_planner_focus_live_test.exs
+++ b/test/grocery_planner_web/live/meal_planner_focus_live_test.exs
@@ -8,7 +8,8 @@ defmodule GroceryPlannerWeb.MealPlannerFocusLiveTest do
     account = create_account()
     user = create_user(account)
 
-    {:ok, user} = GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "focus"})
+    {:ok, user} =
+      GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "focus"}, actor: user)
 
     conn =
       build_conn()

--- a/test/grocery_planner_web/live/meal_planner_live/explorer_layout_test.exs
+++ b/test/grocery_planner_web/live/meal_planner_live/explorer_layout_test.exs
@@ -19,7 +19,8 @@ defmodule GroceryPlannerWeb.MealPlannerLive.ExplorerLayoutTest do
     create_recipe(account, user, %{name: "Toast", prep_time_minutes: 2, cook_time_minutes: 2})
 
     # Set layout to explorer
-    {:ok, user} = GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "explorer"})
+    {:ok, user} =
+      GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "explorer"}, actor: user)
 
     today = Date.utc_today()
     week_start = Date.add(today, -(Date.day_of_week(today) - 1))

--- a/test/grocery_planner_web/live/meal_planner_live_test.exs
+++ b/test/grocery_planner_web/live/meal_planner_live_test.exs
@@ -7,7 +7,8 @@ defmodule GroceryPlannerWeb.MealPlannerLiveTest do
     account = create_account()
     user = create_user(account)
 
-    {:ok, user} = GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "focus"})
+    {:ok, user} =
+      GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "focus"}, actor: user)
 
     today = Date.utc_today()
     week_start = Date.add(today, -(Date.day_of_week(today) - 1))
@@ -70,7 +71,7 @@ defmodule GroceryPlannerWeb.MealPlannerLiveTest do
       assert has_element?(view, "#explorer-timeline")
       assert has_element?(view, "#meal-planner-layout-explorer")
 
-      updated_user = Ash.get!(GroceryPlanner.Accounts.User, user.id)
+      {:ok, updated_user} = GroceryPlanner.Accounts.User.by_id(user.id, actor: user)
       assert updated_user.meal_planner_layout == "explorer"
     end
   end

--- a/test/grocery_planner_web/live/meal_planner_power_mode_test.exs
+++ b/test/grocery_planner_web/live/meal_planner_power_mode_test.exs
@@ -11,7 +11,8 @@ defmodule GroceryPlannerWeb.MealPlannerPowerModeTest do
     user = create_user(account)
 
     # Set user to power mode
-    {:ok, user} = GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "power"})
+    {:ok, user} =
+      GroceryPlanner.Accounts.User.update(user, %{meal_planner_layout: "power"}, actor: user)
 
     today = Date.utc_today()
     week_start = Date.add(today, -(Date.day_of_week(today) - 1))

--- a/test/grocery_planner_web/live/settings_live_test.exs
+++ b/test/grocery_planner_web/live/settings_live_test.exs
@@ -3,6 +3,8 @@ defmodule GroceryPlannerWeb.SettingsLiveTest do
   import Phoenix.LiveViewTest
   import GroceryPlanner.InventoryTestHelpers
 
+  alias GroceryPlanner.Accounts
+
   setup do
     account = create_account()
     user = create_user(account)
@@ -114,8 +116,68 @@ defmodule GroceryPlannerWeb.SettingsLiveTest do
 
       assert render(view) =~ "Profile updated successfully"
 
-      {:ok, updated_user} = GroceryPlanner.Accounts.User.by_id(user.id)
+      {:ok, updated_user} = GroceryPlanner.Accounts.User.by_id(user.id, actor: user)
       assert updated_user.meal_planner_layout == "explorer"
+    end
+  end
+
+  describe "Member role authorization" do
+    setup %{account: account} do
+      {:ok, member} =
+        Accounts.User.create("member@example.com", "Member User", "password123456",
+          authorize?: false
+        )
+
+      {:ok, _membership} =
+        Accounts.AccountMembership.create(account.id, member.id, %{role: :member},
+          authorize?: false
+        )
+
+      member_conn =
+        build_conn()
+        |> init_test_session(%{user_id: member.id, account_id: account.id})
+
+      %{member_conn: member_conn, member: member}
+    end
+
+    test "member cannot add an owner via a forged invitation event", %{
+      member_conn: member_conn,
+      account: account
+    } do
+      {:ok, view, _html} = live(member_conn, "/settings")
+
+      render_submit(view, "send_invitation", %{
+        "email" => "colluder@example.com",
+        "role" => "owner"
+      })
+
+      assert render(view) =~ "You do not have permission to add members"
+
+      {:ok, memberships} = Accounts.AccountMembership.read(authorize?: false)
+      account_memberships = Enum.filter(memberships, &(&1.account_id == account.id))
+
+      # only the pre-existing owner + member, no colluder was added
+      assert length(account_memberships) == 2
+    end
+
+    test "member cannot remove the owner via a forged remove event", %{
+      member_conn: member_conn,
+      account: account,
+      user: owner
+    } do
+      {:ok, view, _html} = live(member_conn, "/settings")
+
+      {:ok, memberships} = Accounts.AccountMembership.read(authorize?: false)
+
+      owner_membership =
+        Enum.find(memberships, &(&1.account_id == account.id and &1.user_id == owner.id))
+
+      render_click(view, "remove_member", %{"id" => owner_membership.id})
+
+      assert render(view) =~ "You do not have permission to remove members"
+
+      {:ok, memberships_after} = Accounts.AccountMembership.read(authorize?: false)
+      assert Enum.any?(memberships_after, &(&1.id == owner_membership.id))
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes grocery_planner-fk7 (P0): any :member of a shared account could add a colluding :owner and remove the real owner, because AccountMembership had a blanket authorize_if always() policy and User update/destroy were unscoped (any actor could edit any user's email). settings_live's send_invitation/remove_member also never passed an actor or checked the caller's role - a forged websocket event was enough.

- AccountMembership: create/update/destroy now require the actor to be owner/admin of the target account (new ActorOwnerOrAdminOfAccount check). Read stays open to any account member.
- User: read/update/destroy scoped to self (read also allows an account-mate to see roster info, via the membership graph), using the same expr(id == ^actor(:id)) / relates_to_actor_via idioms already used elsewhere (e.g. FilterPreset, Account).
- settings_live: send_invitation/remove_member now check current_role in [:owner, :admin] before touching AccountMembership, and pass actor: on every Accounts call (previously several were actor-less, which is why the broken policy went unnoticed).

### Additional scope: found and fixed a related latent bug in Account

While fixing the above I found Account's own update/destroy policy used relates_to_actor_via(path, filter: [role: [:owner, :admin]]) - but Ash's relates_to_actor_via/2 builtin has no filter: option; it's silently ignored. So any member (not just owner/admin) could already rename or destroy the whole account. The existing test for this had a `{:ok, _} -> assert true` escape hatch that masked it. Reused the new ActorOwnerOrAdminOfAccount check to fix Account too, and tightened that test to assert Forbidden strictly.

### Pre-auth call sites

Tightening User's read policy meant every place that resolves "who is this user" before there's an authenticated actor (login, session restore from cookie, password-reset token lookup, API bearer-token auth) needed authorize?: false, matching the existing project convention for actor-nil system operations. Fixed all of them: auth.ex, both AuthControllers, forgot_password_live.ex, reset_password_live.ex, api_auth.ex. Also fixed the existing ActorMemberOfAccount check's internal existence query the same way - it was transitively broken by tightening AccountMembership's read policy.

### Deliberately out of scope

An owner/admin can still demote or remove another owner - the AC only requires gating owner/admin vs. member.

## Test plan
- mix test - 967 tests, 0 failures (baseline was 234 in this test slice before the fix)
- New tests: member cannot create/update/destroy AccountMembership (incl. role-escalation and owner-removal via forged settings_live events), Account update strictly denies non-owner/admin
- mix compile --warnings-as-errors clean
- mix format --check-formatted clean
- ruff step of mix precommit could not run in this sandbox (binary unavailable, unrelated to this change); will run in CI

Generated with Claude Code