### PR TITLE
fix(onboarding): resolve recipe catalog via app dir, not cwd (P0)

### DIFF
--- a/lib/grocery_planner/onboarding/starter_data.ex
+++ b/lib/grocery_planner/onboarding/starter_data.ex
@@ -90,7 +90,8 @@ defmodule GroceryPlanner.Onboarding.StarterData do
   end
 
   defp load_catalog do
-    "priv/recipe_catalog.json"
+    :grocery_planner
+    |> Application.app_dir("priv/recipe_catalog.json")
     |> File.read!()
     |> Jason.decode!(keys: :atoms)
   end

--- a/test/grocery_planner/onboarding/starter_data_test.exs
+++ b/test/grocery_planner/onboarding/starter_data_test.exs
@@ -1,0 +1,33 @@
+defmodule GroceryPlanner.Onboarding.StarterDataTest do
+  # async: false — the cwd-independence test changes the VM-global working
+  # directory, which would race with concurrently running tests.
+  use ExUnit.Case, async: false
+
+  alias GroceryPlanner.Onboarding.StarterData
+
+  describe "recipe catalog loading" do
+    test "loads the catalog via the app dir, independent of cwd" do
+      # In a release the process cwd is not the project root and priv/ lives
+      # under the app's lib dir, so a cwd-relative "priv/..." read crashes
+      # onboarding. Simulate that by leaving the project root entirely.
+      {:ok, original_cwd} = File.cwd()
+
+      try do
+        File.cd!(System.tmp_dir!())
+
+        recipes = StarterData.recipes(:omnivore)
+
+        assert recipes != []
+        assert Enum.all?(recipes, &is_binary(&1.name))
+      after
+        File.cd!(original_cwd)
+      end
+    end
+
+    test "every kit resolves to a non-empty recipe list" do
+      for kit <- StarterData.kits() do
+        assert StarterData.recipes(kit) != [], "kit #{kit} produced no recipes"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes grocery_planner-9rv (P0): `starter_data.ex` read `priv/recipe_catalog.json` with a cwd-relative path. That works in dev (cwd is the project root) but crashes in a release, where cwd differs and priv lives under the app's lib dir - so every new-account onboarding failed in production with `File.Error`.

- `load_catalog/0` now resolves the path with `Application.app_dir(:grocery_planner, "priv/recipe_catalog.json")`.
- The other two priv-referencing sites in lib/ (`receipts_live.ex`, `process_receipt.ex`) already use `:code.priv_dir/1` and are release-safe; grep confirms no other cwd-relative file reads remain in lib/.

## Test plan

- New regression test changes cwd to tmp before loading the catalog, reproducing the release condition. Verified it fails against the old code (red) and passes with the fix (green). `async: false` because cwd is VM-global.
- Second test asserts every kit resolves to a non-empty recipe list.
- Full suite: 969 tests, 0 failures. `mix format --check-formatted` clean.

Generated with Claude Code