### PR TITLE
fix(recipes): stop recipe import duplicating grocery items and swallowing failures (P0)

### DIFF
--- a/lib/grocery_planner/external/recipe_importer.ex
+++ b/lib/grocery_planner/external/recipe_importer.ex
@@ -28,36 +28,45 @@ defmodule GroceryPlanner.External.RecipeImporter do
 
   @doc """
   Imports a list of ingredients for a recipe, creating grocery items as needed.
+
+  Returns `:ok` when every ingredient was created, or `{:error, error}` for the
+  first ingredient that failed.
   """
   def import_ingredients(ingredients, recipe_id, account_id) do
     ingredients
     |> Enum.with_index(1)
-    |> Enum.each(fn {ingredient, index} ->
+    |> Enum.reduce_while(:ok, fn {ingredient, index}, :ok ->
+      {quantity, unit} = parse_measure(ingredient.measure)
+
       with {:ok, grocery_item} <- find_or_create_grocery_item(ingredient.name, account_id),
-           {quantity, unit} <- parse_measure(ingredient.measure) do
-        GroceryPlanner.Recipes.create_recipe_ingredient(
-          account_id,
-          %{
-            recipe_id: recipe_id,
-            grocery_item_id: grocery_item.id,
-            quantity: quantity,
-            unit: unit,
-            sort_order: index
-          },
-          authorize?: false,
-          tenant: account_id
-        )
+           {:ok, _recipe_ingredient} <-
+             GroceryPlanner.Recipes.create_recipe_ingredient(
+               account_id,
+               %{
+                 recipe_id: recipe_id,
+                 grocery_item_id: grocery_item.id,
+                 quantity: quantity,
+                 unit: unit,
+                 sort_order: index
+               },
+               authorize?: false,
+               tenant: account_id
+             ) do
+        {:cont, :ok}
+      else
+        {:error, error} -> {:halt, {:error, error}}
       end
     end)
-
-    :ok
   end
 
   @doc """
   Finds an existing grocery item by name (case-insensitive) or creates a new one.
   """
   def find_or_create_grocery_item(item_name, account_id) do
-    case GroceryPlanner.Inventory.list_grocery_items(tenant: account_id) do
+    # authorize?: false, not a nil actor: with no actor, relates_to_actor_via
+    # policies silently return [] and every import duplicates grocery items
+    # (see item_matcher.ex for the same convention).
+    case GroceryPlanner.Inventory.list_grocery_items(authorize?: false, tenant: account_id) do
       {:ok, items} ->
         case Enum.find(items, fn item ->
                String.downcase(item.name) == String.downcase(item_name)

--- a/test/grocery_planner/external/recipe_importer_import_test.exs
+++ b/test/grocery_planner/external/recipe_importer_import_test.exs
@@ -1,0 +1,75 @@
+defmodule GroceryPlanner.External.RecipeImporterImportTest do
+  use GroceryPlanner.DataCase, async: true
+
+  alias GroceryPlanner.Accounts
+  alias GroceryPlanner.External.RecipeImporter
+  alias GroceryPlanner.External.TheMealDB
+  alias GroceryPlanner.Inventory
+
+  @base_meal %{
+    "idMeal" => "52940",
+    "strMeal" => "Brown Stew Chicken",
+    "strCategory" => "Chicken",
+    "strArea" => "Jamaican",
+    "strInstructions" => "Instructions...",
+    "strMealThumb" => "https://example.com/image.jpg",
+    "strYoutube" => "",
+    "strSource" => "",
+    "strTags" => "Stew",
+    "strIngredient1" => "Chicken",
+    "strMeasure1" => "1 whole",
+    "strIngredient2" => "Tomato",
+    "strMeasure2" => "2",
+    "strIngredient3" => "Onions",
+    "strMeasure3" => "2 chopped"
+  }
+
+  setup do
+    {:ok, account} = Accounts.Account.create(%{name: "Import Test"}, authorize?: false)
+    %{account: account}
+  end
+
+  defp stub_lookup(meal) do
+    Req.Test.stub(TheMealDB, fn conn ->
+      Req.Test.json(conn, %{"meals" => [meal]})
+    end)
+  end
+
+  defp grocery_item_names(account) do
+    {:ok, items} = Inventory.list_grocery_items(authorize?: false, tenant: account.id)
+    items |> Enum.map(& &1.name) |> Enum.sort()
+  end
+
+  describe "import_recipe/2" do
+    test "creates the recipe with its ingredients", %{account: account} do
+      stub_lookup(@base_meal)
+
+      assert {:ok, recipe} = RecipeImporter.import_recipe("52940", account.id)
+      assert recipe.name == "Brown Stew Chicken"
+
+      recipe = Ash.load!(recipe, [:recipe_ingredients], authorize?: false, tenant: account.id)
+      assert length(recipe.recipe_ingredients) == 3
+      assert grocery_item_names(account) == ["Chicken", "Onions", "Tomato"]
+    end
+
+    test "re-importing does not duplicate grocery items", %{account: account} do
+      stub_lookup(@base_meal)
+
+      assert {:ok, _recipe} = RecipeImporter.import_recipe("52940", account.id)
+      names_after_first = grocery_item_names(account)
+
+      assert {:ok, _recipe} = RecipeImporter.import_recipe("52940", account.id)
+
+      assert grocery_item_names(account) == names_after_first
+    end
+
+    test "surfaces an ingredient creation failure as an error", %{account: account} do
+      # A whitespace-only ingredient survives TheMealDB parsing as name: ""
+      # and fails GroceryItem's allow_nil? false - previously this was
+      # silently swallowed and the import reported success.
+      stub_lookup(Map.merge(@base_meal, %{"strIngredient2" => "   ", "strMeasure2" => "2"}))
+
+      assert {:error, _error} = RecipeImporter.import_recipe("52940", account.id)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes grocery_planner-mi4 (P0). Two defects in `RecipeImporter`:

1. **Duplicate grocery items on every import.** `find_or_create_grocery_item` called `Inventory.list_grocery_items(tenant: account_id)` with no actor and no `authorize?: false` - the documented nil-actor pitfall: the `relates_to_actor_via` policy silently returns `[]` instead of raising, so "find" never found anything and every import created a fresh copy of each ingredient. Now passes `authorize?: false`, matching the convention in `item_matcher.ex`.

2. **Swallowed ingredient failures.** `import_ingredients` ran a no-else `with` inside `Enum.each`, discarded every `create_recipe_ingredient` result, and returned `:ok` unconditionally - recipes imported as "success" with missing ingredients. Now a `reduce_while` that halts on the first failure and returns `{:error, error}`, which `import_recipe`'s `with` propagates to callers (both LiveView callers already handle `{:error, _}`).

### Out of scope

On failure the recipe and already-created ingredients are not rolled back - transactional import is a separate concern (same class as the `confirm_swap` transactionality issue, tracked separately as grocery_planner-iyf).

## Test plan

- New tests stub TheMealDB via the existing `Req.Test` setup and drive the real `import_recipe/2`:
  - re-importing the same recipe leaves grocery items unchanged
  - a whitespace-only ingredient name (dirty API data that survives parsing as `""` and fails `GroceryItem`'s `allow_nil? false`) surfaces as `{:error, _}` from `import_recipe`
- Both regression tests verified **red against the old code** (the dedup failure showed `["Chicken", "Chicken", "Onions", "Onions", ...]`) before applying the fix.
- Full suite: 972 tests, 0 failures. `mix format --check-formatted` clean.

Generated with Claude Code